### PR TITLE
deduplicate and streamline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "tag1bot"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tag1bot"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,5 @@
+// Functions for creating, updating and sharing the sqlite database.
+
 use rusqlite::Connection;
 use std::sync::{Arc, Mutex};
 

--- a/src/karma.rs
+++ b/src/karma.rs
@@ -1,24 +1,19 @@
+// Tracks keyword karma.
+// For example, `foo++` or `bar--`.
+
 use regex::{Regex, RegexSet};
 use rusqlite::params;
 
 use crate::db::DB;
-use crate::slack::User;
+use crate::slack;
 use crate::TAG1BOT_USER;
 
 const REGEX_KARMA_PLUS: &str = r"^(\w{2,20})\+\+$";
 const REGEX_KARMA_MINUS: &str = r"^(\w{2,20})\-\-$";
 
-// Details needed to determine if a message modifies karma and to build a reply.
-pub(crate) struct KarmaMessage {
-    pub(crate) user: User,
-    pub(crate) text: String,
-    pub(crate) thread_ts: Option<String>,
-    pub(crate) ts: String,
-}
-
 // Determine if Karma is being modified in this message. Returns `Some(thread id, message)` if karma
 // is modified, returns `None` if not,
-pub(crate) async fn process_message(message: &KarmaMessage) -> Option<(String, String)> {
+pub(crate) async fn process_message(message: &slack::Message) -> Option<(String, String)> {
     if message.user.id != TAG1BOT_USER {
         let trimmed_text = message.text.trim();
         let set = RegexSet::new(&[REGEX_KARMA_PLUS, REGEX_KARMA_MINUS])

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+// General utility functions.
+
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // Basic auth is a "username:password" secret that is base64 encoded.


### PR DESCRIPTION
 - remove per-type message types, using a shared `slack::Message` type with everything
 - move more custom slack logic into mod slack
 - clippy cleanups